### PR TITLE
Add ability to ignore video tasks on import + new minor utility command

### DIFF
--- a/volunteers/management/commands/delete_tasks.py
+++ b/volunteers/management/commands/delete_tasks.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from volunteers.models import Task, TaskTemplate
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        if len(args) <= 0:
+            valid_choices = ', '.join([tt.name for tt in TaskTemplate.objects.all()])
+            raise Exception(
+                "Please specify the type of task you would like to delete as the first argument, e.g. ./manage.py delete_tasks Heralding.\n"
+                "Specify 'all' to delete all tasks.\n"
+                "The types of task in the system are {}".format(valid_choices)
+            )
+        if args[0].lower() == 'all':
+            Task.objects.all().delete()
+        else:
+            Task.objects.filter(template__name=args[0]).delete()

--- a/volunteers/models.py
+++ b/volunteers/models.py
@@ -122,7 +122,7 @@ class Edition(models.Model):
 
                 if room_name in ['Janson', 'K.1.105 (La Fontaine)']:
                     needs_heralding = True
-                    needs_video = settings.IMPORT_VIDEO_TASKS
+                    needs_video = getattr(settings, 'IMPORT_VIDEO_TASKS', True)
 
                 events = room.findall('event')
                 for event in events:

--- a/volunteers/models.py
+++ b/volunteers/models.py
@@ -117,7 +117,13 @@ class Edition(models.Model):
             for room in rooms:
                 room_name = room.get('name')
                 # Lightning talks are done manually since the time slots are so small.
-                needs_heralding = needs_video = room_name in ['Janson', 'K.1.105 (La Fontaine)']
+                needs_heralding = False
+                needs_video = False
+
+                if room_name in ['Janson', 'K.1.105 (La Fontaine)']:
+                    needs_heralding = True
+                    needs_video = settings.IMPORT_VIDEO_TASKS
+
                 events = room.findall('event')
                 for event in events:
                     talk = Talk.penta_create_or_update(event, edition, day_date)


### PR DESCRIPTION
After this PR is merged, the following can be done on the server:

- in `volunteer_mgmt/localsettings.py`, `IMPORT_VIDEO_TASKS = False` can be defined.
- `./manage.py sync_with_penta` can be run
- the Heralding tasks will be created for this year without video tasks.

The other change introduced by this PR is a new command `delete_tasks`, which allows the selective deletion of tasks by type, for local testing. I mostly did it as an exercise to learn how to delete by an attribute, but I think there is some value in keeping the simple query involved in a task. At least until we learn the web app better.